### PR TITLE
Add jpeg direct publishing without decoding

### DIFF
--- a/examples/v4ljpeg.launch
+++ b/examples/v4ljpeg.launch
@@ -10,7 +10,8 @@
   <node ns="v4l" name="gscam_driver_v4l" pkg="gscam" type="gscam" output="screen">
     <param name="camera_name" value="default"/>
     <param name="camera_info_url" value="package://gscam/examples/uncalibrated_parameters.ini"/>
-    <param name="gscam_config" value="v4l2src ! video/x-raw-yuv ! jpegenc ! multipartmux ! multipartdemux ! jpegparse"/>
+    <param name="gscam_config" value="v4l2src do-timestamp=true is-live=true ! video/x-raw-yuv ! jpegenc ! multipartmux ! multipartdemux ! jpegparse"/>
+    <param name="use_gst_timestamps" value="true"/>
     <param name="image_encoding" value="jpeg"/>
     <param name="frame_id" value="/v4l_frame"/>
     <param name="sync_sink" value="true"/>

--- a/include/gscam/gscam.h
+++ b/include/gscam/gscam.h
@@ -43,6 +43,7 @@ namespace gscam {
     bool sync_sink_;
     bool preroll_;
     bool reopen_on_eof_;
+    bool use_gst_timestamps_;
 
     // Camera publisher configuration
     std::string frame_id_;
@@ -52,6 +53,8 @@ namespace gscam {
     std::string camera_info_url_;
 
     // ROS Inteface
+    // Calibration between ros::Time and gst timestamps
+    double time_offset_;
     ros::NodeHandle nh_, nh_private_;
     image_transport::ImageTransport image_transport_;
     camera_info_manager::CameraInfoManager camera_info_manager_;

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -72,6 +72,7 @@ namespace gscam {
     // Get additional gscam configuration
     nh_private_.param("sync_sink", sync_sink_, true);
     nh_private_.param("preroll", preroll_, false);
+    nh_private_.param("use_gst_timestamps", use_gst_timestamps_, false);
 
     nh_private_.param("reopen_on_eof", reopen_on_eof_, false);
 
@@ -183,6 +184,14 @@ namespace gscam {
       }
     }
 
+    // Calibration between ros::Time and gst timestamps
+    GstClock * clock = gst_system_clock_obtain();
+    ros::Time now = ros::Time::now();
+    GstClockTime ct = gst_clock_get_time(clock);
+    gst_object_unref(clock);
+    time_offset_ = now.toSec() - GST_TIME_AS_USECONDS(ct)/1e6;
+    ROS_INFO("Time offset: %.3f",time_offset_);
+
     gst_element_set_state(pipeline_, GST_STATE_PAUSED);
 
     if (gst_element_get_state(pipeline_, NULL, NULL, -1) == GST_STATE_CHANGE_FAILURE) {
@@ -240,17 +249,22 @@ namespace gscam {
     while(ros::ok()) {
       // This should block until a new frame is awake, this way, we'll run at the
       // actual capture framerate of the device.
-      ROS_DEBUG("Getting data...");
+      // ROS_DEBUG("Getting data...");
       GstBuffer* buf = gst_app_sink_pull_buffer(GST_APP_SINK(sink_));
+      GstClockTime bt = gst_element_get_base_time(pipeline_);
+      // ROS_INFO("New buffer: timestamp %.6f %lu %lu %.3f",
+      //         GST_TIME_AS_USECONDS(buf->timestamp+bt)/1e6+time_offset_, buf->timestamp, bt, time_offset_);
 
 
+#if 0
       GstFormat fmt = GST_FORMAT_TIME;
       gint64 current = -1;
 
-      // Query the current position of the stream
-      //if (gst_element_query_position(pipeline_, &fmt, &current)) {
-        //ROS_INFO_STREAM("Position "<<current);
-      //}
+       Query the current position of the stream
+      if (gst_element_query_position(pipeline_, &fmt, &current)) {
+          ROS_INFO_STREAM("Position "<<current);
+      }
+#endif
 
       // Stop on end of stream
       if (!buf) {
@@ -258,7 +272,7 @@ namespace gscam {
         break;
       }
 
-      ROS_DEBUG("Got data.");
+      // ROS_DEBUG("Got data.");
 
       // Get the image width and height
       GstPad* pad = gst_element_get_static_pad(sink_, "sink");
@@ -270,7 +284,12 @@ namespace gscam {
       // Update header information
       sensor_msgs::CameraInfoPtr cinfo;
       cinfo.reset(new sensor_msgs::CameraInfo(camera_info_manager_.getCameraInfo()));
-      cinfo->header.stamp = ros::Time::now();
+      if (use_gst_timestamps_) {
+          cinfo->header.stamp = ros::Time(GST_TIME_AS_USECONDS(buf->timestamp+bt)/1e6+time_offset_);
+      } else {
+          cinfo->header.stamp = ros::Time::now();
+      }
+      // ROS_INFO("Image time stamp: %.3f",cinfo->header.stamp.toSec());
       cinfo->header.frame_id = frame_id_;
       if (image_encoding_ == "jpeg") {
           sensor_msgs::CompressedImagePtr img(new sensor_msgs::CompressedImage());


### PR DESCRIPTION
This patch add an image_encoding = "jpeg" to gscam, to create a gstreamer pipeline just connecting to one of these webcams producing mjpeg (e.g. axis camera) but without decoding the stream. On some embedded system, this is useful to log the video stream as jpegs but only decompress it on request. 

The behaviour is roughly the same as the axis_camera driver, but without the huge latency sometimes introduced by python. 

Without the parameter "image_encoding == jpeg", the patch does not change anything to the code.
