### PR TITLE
Install the parameters file refered to in v4l.launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,10 @@ else()
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
     )
 
+  install(FILES examples/uncalibrated_parameters.ini
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/examples
+    )
+
   # Interim compatibility
   # Remove this in the next release
   install(FILES ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/gscam_node


### PR DESCRIPTION
Ensure that the uncalibrated_parameters.ini file is copied during the install because otherwise the user gets an error running the example v4l.launch file at [line 12](https://github.com/dhood/gscam/blob/master/examples/v4l.launch#L12)