### PR TITLE
Remove dependency on opencv2 to fix under indigo

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,7 @@
   <build_depend>libgstreamer-plugins-base0.10-dev</build_depend>
 
   <build_depend>nodelet</build_depend>
-  <build_depend>opencv2</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -26,7 +26,7 @@
   <build_depend>camera_info_manager</build_depend>
 
   <run_depend>nodelet</run_depend>
-  <run_depend>opencv2</run_depend>
+  <run_depend>cv_bridge</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
Packages can no longer depend on opencv2 as of indigo. 
I've updated the package to depend instead on cv_bridge as suggested by http://wiki.ros.org/indigo/Migration#OpenCV.