### PR TITLE
Replace build and run depend of opencv2 with opencv3.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,7 @@
   <build_depend>libgstreamer-plugins-base0.10-dev</build_depend>
 
   <build_depend>nodelet</build_depend>
-  <build_depend>opencv2</build_depend>
+  <build_depend>opencv3</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -26,7 +26,7 @@
   <build_depend>camera_info_manager</build_depend>
 
   <run_depend>nodelet</run_depend>
-  <run_depend>opencv2</run_depend>
+  <run_depend>opencv3</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
rosdep install gscam
does not work because ros-indigo-opencv2 is deprecated.

Insread, ros-indigo-opencv3 is available, so I replaced opencv2 with opencv3 in package.xml.