### PR TITLE
Allow stopping a stream before EOS

### DIFF
--- a/include/gscam/gscam.h
+++ b/include/gscam/gscam.h
@@ -30,6 +30,7 @@ namespace gscam {
     void cleanup_stream();
 
     void run();
+    void stop();
 
   private:
     // General gstreamer configuration

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -389,6 +389,14 @@ namespace gscam {
 
   }
 
+  void GSCam::stop() {
+    ROS_INFO("Stop requested");
+    reopen_on_eof_ = false;
+    if(pipeline_) {
+      gst_element_set_state(pipeline_, GST_STATE_NULL);
+    }
+  }
+
   // Example callbacks for appsink
   // TODO: enable callback-based capture
   void gst_eos_cb(GstAppSink *appsink, gpointer user_data ) {

--- a/src/gscam_nodelet.cpp
+++ b/src/gscam_nodelet.cpp
@@ -16,6 +16,7 @@ namespace gscam {
 
   GSCamNodelet::~GSCamNodelet() 
   {
+    gscam_driver_->stop();
     stream_thread_->join();
   }
 


### PR DESCRIPTION
When unloading a gscam nodelet, the thread join may block forever if the stream does not have an end.
For example, an rtp/udp video source.
Adding a stop function to GSCam will prevent the infinite hangout.