### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/gscam_nodelet.cpp
+++ b/src/gscam_nodelet.cpp
@@ -4,7 +4,7 @@
 #include <pluginlib/class_list_macros.h>
 #include <gscam/gscam_nodelet.h>
 
-PLUGINLIB_DECLARE_CLASS(gscam, GSCamNodelet, gscam::GSCamNodelet, nodelet::Nodelet) 
+PLUGINLIB_EXPORT_CLASS(gscam::GSCamNodelet, nodelet::Nodelet) 
 
 namespace gscam {
   GSCamNodelet::GSCamNodelet() :


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions