### PR TITLE
Fixed incorrect unref for gstreamer >= 1.16.

### DIFF
--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -392,7 +392,12 @@ namespace gscam {
         gst_memory_unmap(memory, &info);
         gst_memory_unref(memory);
 #endif
+
+#if(GST_VERSION_MAJOR >= 1 && GST_VERSION_MINOR >= 16)
+        gst_sample_unref(sample);
+#else
         gst_buffer_unref(buf);
+#endif
       }
 
       ros::spinOnce();


### PR DESCRIPTION
The buffer is accessed through gst_sample_get_buffer.  The buffer shouldn't be unrefed the sample should be, however, this doesn't seem work in gstreamer 1.14.  If the buffer is unreffed in 1.16 it eventually causes a segfault.

I tested this fix with gstreamer 1.16 and 1.14, it works with both.