### PR TITLE
add MONO16 / GRAY16_LE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This can be run as both a node and a nodelet.
 * `~frame_id`: The [TF](http://www.ros.org/wiki/tf) frame ID.
 * `~reopen_on_eof`: Re-open the stream if it ends (EOF).
 * `~sync_sink`: Synchronize the app sink (sometimes setting this to `false` can resolve problems with sub-par framerates).
+* `~image_encoding`: Encoding of the stream. Can be {`rgb8`,`mono8`,`mono16`}. Defaults to `rgb8`.
 
 C++ API (unstable)
 ------------------


### PR DESCRIPTION
added support for MONO16/GRAY16_LE streams.

tested with a 12bit thermal camera (mapped to 16bit) on gstreamer1.0.