### PR TITLE
Initialize variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea/
-cmake-build-debug/
-.cmake-build-debug/
+cmake-build-*
+.cmake-build-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Build the image:
+# docker build --build-arg ROS_DISTRO=$ROS_DISTRO --tag gscam:$ROS_DISTRO .
+
+# Run a test:
+# docker run -it gscam:$ROS_DISTRO
+
+# Interactive session with Rocker (https://github.com/osrf/rocker):
+# rocker --x11 --nvidia gscam:$ROS_DISTRO bash
+
+ARG ROS_DISTRO
+
+FROM osrf/ros:${ROS_DISTRO}-desktop
+
+RUN apt-get update && apt-get upgrade -y
+
+RUN apt-get install -y libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+ gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-doc \
+ gstreamer1.0-tools gstreamer1.0-x gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 \
+ gstreamer1.0-qt5 gstreamer1.0-pulseaudio libgstreamer-plugins-base1.0-dev
+
+WORKDIR /work/gscam_ws/src
+
+RUN git clone https://github.com/ros-drivers/gscam.git -b ros2
+
+WORKDIR /work/gscam_ws
+
+RUN rosdep install -y --from-paths . --ignore-src
+
+RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash && colcon build"
+
+ENV GSCAM_CONFIG='videotestsrc pattern=snow ! video/x-raw,width=1280,height=720 ! videoconvert'
+
+ENV GST_DEBUG=3
+
+CMD ["/bin/bash", "-c", "source install/local_setup.bash && ros2 run gscam gscam_node"]
+
+# This works in Galactic and Rolling, but not Foxy:
+# ros2 run gscam gscam_node --ros-args --log-level gscam_publisher:=debug

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -42,7 +42,8 @@ GSCam::GSCam(const rclcpp::NodeOptions & options)
   gsconfig_(""),
   pipeline_(NULL),
   sink_(NULL),
-  camera_info_manager_(this)
+  camera_info_manager_(this),
+  stop_signal_(false)
 {
   pipeline_thread_ = std::thread(
     [this]()


### PR DESCRIPTION
I noticed a few intermittent failures while doing some more testing on Rolling and Galactic. I traced it down to an uninitialized variable. I should have caught this earlier. :(

I also added a simple Dockerfile.

Rolling CI is failing, but this is related to https://github.com/ros-tooling/action-ros-ci/issues/722

@wep21 @jbohren can you take a look?