### PR TITLE
Improve Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.idea/
+cmake-build-*
+.cmake-build-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,15 @@ RUN apt-get install -y libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-
  gstreamer1.0-tools gstreamer1.0-x gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 \
  gstreamer1.0-qt5 gstreamer1.0-pulseaudio libgstreamer-plugins-base1.0-dev
 
-WORKDIR /work/gscam_ws/src
-
-RUN git clone https://github.com/ros-drivers/gscam.git -b ros2
-
 WORKDIR /work/gscam_ws
 
+# Copy package.xml for rosdep, this doesn't change often
+COPY package.xml src/
+
 RUN rosdep install -y --from-paths . --ignore-src
+
+# Copy everything for colcon build
+COPY . src/
 
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash && colcon build"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,10 @@ RUN apt-get install -y libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-
 
 WORKDIR /work/gscam_ws
 
-# Copy package.xml for rosdep, this doesn't change often
-COPY package.xml src/
-
-RUN rosdep install -y --from-paths . --ignore-src
-
 # Copy everything for colcon build
-COPY . src/
+COPY . src/gscam/
 
+RUN rosdep install -y --from-paths src --ignore-src
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash && colcon build"
 
 ENV GSCAM_CONFIG='videotestsrc pattern=snow ! video/x-raw,width=1280,height=720 ! videoconvert'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ARG ROS_DISTRO
 
 FROM osrf/ros:${ROS_DISTRO}-desktop
 
+ARG ROS_DISTRO
+
 RUN apt-get update && apt-get upgrade -y
 
 RUN apt-get install -y libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
@@ -30,7 +32,7 @@ ENV GSCAM_CONFIG='videotestsrc pattern=snow ! video/x-raw,width=1280,height=720 
 
 ENV GST_DEBUG=3
 
-CMD ["/bin/bash", "-c", "source install/local_setup.bash && ros2 run gscam gscam_node"]
+CMD ["/bin/bash", "-c", "source install/setup.bash && ros2 run gscam gscam_node"]
 
 # This works in Galactic and Rolling, but not Foxy:
 # ros2 run gscam gscam_node --ros-args --log-level gscam_publisher:=debug


### PR DESCRIPTION
* use COPY instead of git clone, this provides better support for developer workflows
* add .dockerignore to avoid copying IDE artifacts into the docker images
* fix usage of the ROS_DISTRO ARG. This appeared to be working before because the upstream osrf image set the ROS_DISTRO env var in the image, but it was confusing.

I re-tested the 'core 4' launch files in Foxy, Galactic and Rolling.

@jbohren @wep21 Sorry for the late PR and extra work.
