### PR TITLE
ci: update docker image for latest ros distribution

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,7 +28,7 @@ jobs:
             ros_distribution: galactic
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-rolling-ros-base-latest
+          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest
             ros_distribution: rolling
             ros_version: 2
     container:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,6 +45,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ros_ws/src
+      - name: workaround for jammy
+        if: ${{ matrix.ros_distribution == 'humble' || matrix.ros_distribution == 'rolling' }}
+        run: |
+          sudo apt remove libunwind-14-dev -y
       - name: build and test
         uses: ros-tooling/action-ros-ci@master
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,6 +17,7 @@ jobs:
         ros_distribution:
           - foxy
           - galactic
+          - humble
           - rolling
         include:
           # Foxy Fitzroy (June 2020 - May 2023)
@@ -26,6 +27,10 @@ jobs:
           # Galactic Geochelone (May 2021 - November 2022)
           - docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-galactic-ros-base-latest
             ros_distribution: galactic
+            ros_version: 2
+          # Humble Hawksbill (May 2022 - May 2027)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
+            ros_distribution: humble
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
           - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest


### PR DESCRIPTION
Related PR: https://github.com/ros-tooling/setup-ros-docker/pull/43