### PR TITLE
docs: update versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GSCam ![example branch parameter](https://github.com/clydemcqueen/gscam/actions/workflows/build_test.yml/badge.svg?branch=ros2)
+# GSCam ![ROS2 CI](https://github.com/ros-drivers/gscam/actions/workflows/build_test.yml/badge.svg?branch=ros2)
 
 This is a ROS2 package originally developed by the [Brown Robotics
 Lab](http://robotics.cs.brown.edu/) for broadcasting any
@@ -13,9 +13,8 @@ GSCam supports the following versions of ROS2 and GStreamer:
 |---|---|---|
 | Foxy | 20.04 | 1.16 |
 | Galactic | 20.04 | 1.16 |
-| Rolling | 20.04 | 1.16 |
-
-Note: Rolling will migrate to Ubuntu 22.04 and GStreamer 1.18 in preparation for Humble Hawksbill.
+| Humble | 22.04 | 1.20 |
+| Rolling | 22.04 | 1.20 |
 
 #### Dependencies
 


### PR DESCRIPTION
* the build badge references clydemcqueen/gscam, it should reference ros-drivers/gscam
* the GStreamer version for Rolling should be 1.20, not 1.18
* Humble should be added to the list of supported versions
