### PR TITLE
Shutdown node when pipeline thread finishes

### DIFF
--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -454,6 +454,7 @@ void GSCam::run()
       break;
     }
   }
+  rclcpp::shutdown();
 }
 
 // Example callbacks for appsink


### PR DESCRIPTION
The node currently hangs if the pipeline thread finishes.  This prevents the use of ROS launch configurations such as setting the node to "required" or respawning the node on exit.  Respawning is particularily usefull when using gstreamer with rtsp if for whatever reason the network is unstable or if the rtsp server crashes - the entire system can be more robust to failure.

This PR makes sure the ROS2 node shuts down when the pipeline thread finishes.