### PR TITLE
deps: add gstreamer1.0-plugins-good

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
 
   <depend>libgstreamer1.0-dev</depend>
   <depend>libgstreamer-plugins-base1.0-dev</depend>
+  <depend>gstreamer1.0-plugins-good</depend>
 
   <depend>class_loader</depend>
   <depend>cv_bridge</depend>


### PR DESCRIPTION
The video4linux2 support is provided by gstreamer1.0-plugins-good. Add it as user might expect gscam to be able to access their eg webcams.