### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,15 @@ target_link_libraries(gscam
   ${ament_LIBRARIES}
   ${GSTREAMER_LIBRARIES}
   ${GST_APP_LIBRARIES})
-ament_target_dependencies(gscam
+target_link_libraries(gscam PUBLIC
   "class_loader"
   "image_transport"
   "rclcpp"
   "rclcpp_components"
   "sensor_msgs"
   "camera_calibration_parsers"
-  "camera_info_manager")
+  "camera_info_manager"
+)
 
 rclcpp_components_register_node(gscam
   PLUGIN "gscam::GSCam"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,18 +23,19 @@ include_directories(
   ${GST_APP_INCLUDE_DIRS})
 
 add_library(gscam SHARED src/gscam.cpp)
-target_link_libraries(gscam
+target_link_libraries(gscam PUBLIC
   ${ament_LIBRARIES}
   ${GSTREAMER_LIBRARIES}
-  ${GST_APP_LIBRARIES})
-target_link_libraries(gscam PUBLIC
-  "class_loader"
-  "image_transport"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs"
-  "camera_calibration_parsers"
-  "camera_info_manager"
+  ${GST_APP_LIBRARIES}
+  ${sensor_msgs_TARGETS}
+  camera_calibration_parsers::camera_calibration_parsers
+  camera_info_manager::camera_info_manager
+  class_loader::class_loader
+  image_transport::image_transport
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  sensor_msgs::sensor_msgs_library
 )
 
 rclcpp_components_register_node(gscam


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
