### PR TITLE
Initialize CameraInfo width/height from frame size

### DIFF
--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -359,6 +359,15 @@ void GSCam::publish_stream()
     }
     // RCLCPP_INFO(get_logger(), "Image time stamp: %.3f",cinfo->header.stamp.toSec());
     cinfo->header.frame_id = frame_id_;
+    // Set width/height from frame size if either is missing
+    if (cinfo->width == 0 || cinfo->height == 0) {
+      if (cinfo->k[0] != 0.0) {  // Signifies calibration is present
+        RCLCPP_ERROR_ONCE(get_logger(), "Calibration missing width/height");
+      }
+      cinfo->width = width_;
+      cinfo->height = height_;
+    }
+
     if (image_encoding_ == "jpeg") {
       sensor_msgs::msg::CompressedImage::SharedPtr img(new sensor_msgs::msg::CompressedImage());
       img->header = cinfo->header;


### PR DESCRIPTION
When calibration data is not present, the `CameraInfo` message is published uninitialized, with its `width` and `height` fields set to 0.

Downstream consumers might not expect this. For example, [Foxglove rejects the calibration data and refuses to render the image](https://github.com/orgs/foxglove/discussions/1210).

This change initializes `width` and `height` to the frame size. If it appears that these zeroes come from *bad* calibration data rather than *absent* calibration data, an [error](https://wiki.ros.org/Verbosity%20Levels) is logged to inform the user to correct their calibration data.