### PR TITLE
feat: add sample timeout for gscam stream recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Note that GStreamer is licensed under the LGPL, and GStreamer plugins have their
 * `gscam_config`: The GStreamer [configuration string](https://gstreamer.freedesktop.org/documentation/tools/gst-launch.html?gi-language=c#pipeline-examples)
 * `frame_id`: The [tf2](https://index.ros.org/p/tf2/) frame ID
 * `reopen_on_eof`: Re-open the stream if it ends (EOF)
+* `sample_timeout_ms`: Stop waiting for a sample after this timeout in milliseconds (`0` disables the timeout). With `reopen_on_eof` enabled, the stream is reopened
 * `sync_sink`: Synchronize the app sink (sometimes setting this to `false` can resolve problems with sub-par framerates)
 * `use_gst_timestamps`: Use the GStreamer buffer timestamps for the image message header timestamps (setting this to `false` results in header timestamps being the time that the image buffer transfer is completed)
 * `image_encoding`: image encoding ("rgb8", "mono8", "yuv422", "jpeg")

--- a/include/gscam/gscam.hpp
+++ b/include/gscam/gscam.hpp
@@ -62,6 +62,7 @@ private:
   bool preroll_;
   bool reopen_on_eof_;
   bool use_gst_timestamps_;
+  int sample_timeout_ms_;
 
   // Camera publisher configuration
   std::string frame_id_;

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -97,6 +97,7 @@ bool GSCam::configure()
   sync_sink_ = declare_parameter("sync_sink", true);
   preroll_ = declare_parameter("preroll", false);
   use_gst_timestamps_ = declare_parameter("use_gst_timestamps", false);
+  sample_timeout_ms_ = declare_parameter("sample_timeout_ms", 0);
 
   reopen_on_eof_ = declare_parameter("reopen_on_eof", false);
 
@@ -302,12 +303,15 @@ void GSCam::publish_stream()
   }
   RCLCPP_INFO(get_logger(), "Started stream.");
 
+  const GstClockTime sample_timeout = sample_timeout_ms_ > 0 ?
+    static_cast<GstClockTime>(sample_timeout_ms_) * GST_MSECOND : GST_CLOCK_TIME_NONE;
+
   // Poll the data as fast a spossible
   while (!stop_signal_ && rclcpp::ok()) {
     // This should block until a new frame is awake, this way, we'll run at the
     // actual capture framerate of the device.
     // RCLCPP_DEBUG(get_logger(), "Getting data...");
-    GstSample * sample = gst_app_sink_pull_sample(GST_APP_SINK(sink_));
+    GstSample * sample = gst_app_sink_try_pull_sample(GST_APP_SINK(sink_), sample_timeout);
     if (!sample) {
       RCLCPP_ERROR(get_logger(), "Could not get gstreamer sample.");
       break;


### PR DESCRIPTION
## Problem

`gscam` can hang indefinitely when a stream temporarily stops producing samples, so `reopen_on_eof` may never get a chance to reopen the pipeline. This was observed with looped RTSP streams that periodically restart.

## Cause

`gscam` waits for frames with `gst_app_sink_pull_sample()`, which can block indefinitely if the RTSP pipeline stays alive but no new samples arrive. In that state, `reopen_on_eof` does not get a chance to reopen the stream.

## Solution

Add an optional `sample_timeout_ms` parameter. When set, gscam uses `gst_app_sink_try_pull_sample()` with that timeout. If no sample is received, the loop exits and the existing `reopen_on_eof` logic restarts the stream. Default is 0, preserving the previous blocking behavior.