### PR TITLE
feat: add rgba8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Note that GStreamer is licensed under the LGPL, and GStreamer plugins have their
 * `reopen_on_eof`: Re-open the stream if it ends (EOF)
 * `sync_sink`: Synchronize the app sink (sometimes setting this to `false` can resolve problems with sub-par framerates)
 * `use_gst_timestamps`: Use the GStreamer buffer timestamps for the image message header timestamps (setting this to `false` results in header timestamps being the time that the image buffer transfer is completed)
-* `image_encoding`: image encoding ("rgb8", "mono8", "yuv422", "jpeg")
+* `image_encoding`: image encoding ("rgb8", "mono8", "yuv422", "rgba8", "jpeg")
 * `use_sensor_data_qos`: The flag to use sensor data qos for camera topic(image, camera_info)
 
 ## Examples

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -110,6 +110,7 @@ bool GSCam::configure()
   if (image_encoding_ != sensor_msgs::image_encodings::RGB8 &&
     image_encoding_ != sensor_msgs::image_encodings::MONO8 &&
     image_encoding_ != sensor_msgs::image_encodings::YUV422 &&
+    image_encoding_ != sensor_msgs::image_encodings::RGBA8 &&
     image_encoding_ != "jpeg")
   {
     RCLCPP_FATAL_STREAM(get_logger(), "Unsupported image encoding: " + image_encoding_);
@@ -176,6 +177,11 @@ bool GSCam::init_stream()
     caps = gst_caps_new_simple(
       "video/x-raw",
       "format", G_TYPE_STRING, "UYVY",
+      NULL);
+  } else if (image_encoding_ == sensor_msgs::image_encodings::RGBA8) {
+    caps = gst_caps_new_simple(
+      "video/x-raw",
+      "format", G_TYPE_STRING, "RGBA",
       NULL);
   } else if (image_encoding_ == "jpeg") {
     caps = gst_caps_new_simple("image/jpeg", NULL, NULL);


### PR DESCRIPTION
## Summary
- **What changed**:
Adds `rgba8` support to the `image_encoding` parameter: a new whitelist entry in `GSCam::configure()` and a matching `"format", "RGBA"` caps branch in `GSCam::init_stream()`. `publish_stream()` needed no changes since it already derives frame size/step generically via `numChannels(image_encoding_)`.
- **Why**:
Jetson's `nvvidconv` only natively outputs 4-byte-aligned formats (RGBA/BGRx) or YUV, never plain RGB/BGR. Without this, a pipeline ending in `nvvidconv ! video/x-raw,format=RGBA` had no caps gscam's appsink would accept, and failed with `cannot link outelement(...) -> sink`.
- **Notes for reviewers**:
Same shape as #70 (MONO16/GRAY16_LE) - additive only, no changes to the generic publish path.

## Impact
- **Affected areas**: `src/gscam.cpp` (`configure()`, `init_stream()`), `README.md`
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [ ] Tested in simulation
    * [x] Tested on real HW

- **How to repeat tests**:
```bash
colcon build --packages-select gscam
Verified two ways:
- On a Jetson Orin NX with an ArduCam (imx219): gscam_config ending in nvvidconv ! video/x-raw,format=RGBA, image_encoding: "rgba8" - pipeline links and publishes correctly.
- Hardware-independent repro for reviewers without Jetson hardware: gscam_config: "videotestsrc is-live=true ! video/x-raw,format=RGBA,width=64,height=64,framerate=10/1", image_encoding: "rgba8" - confirms the same caps-negotiation path without needing any Tegra-specific elements.